### PR TITLE
bpo-46208: Passing ntpath and failing posixpath tests for normpath

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -235,6 +235,7 @@ class TestNtpath(NtpathTestCase):
 
         tester("ntpath.normpath('\\\\.\\NUL')", r'\\.\NUL')
         tester("ntpath.normpath('\\\\?\\D:/XY\\Z')", r'\\?\D:/XY\Z')
+        tester("ntpath.normpath('handbook/../../Tests/image.png')", r'..\Tests\image.png')
 
     def test_realpath_curdir(self):
         expected = ntpath.normpath(os.getcwd())

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -336,6 +336,7 @@ class PosixPathTest(unittest.TestCase):
         ("/../foo/../bar", "/bar"),
         ("/../../foo/../bar/./baz/boom/..", "/bar/baz"),
         ("/../../foo/../bar/./baz/boom/.", "/bar/baz/boom"),
+        ("handbook/../../Tests/image.png", "../Tests/image.png")
     ]
 
     def test_normpath(self):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

* `ntpath.normpath('handbook/../../Tests/image.png')" == r'..\Tests\image.png` passes

* `posixpath.normpath("handbook/../../Tests/image.png") == "../Tests/image.png"` fails
