### PR TITLE
Use `:term:` instead for translators

### DIFF
--- a/Doc/tools/extensions/changes.py
+++ b/Doc/tools/extensions/changes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.domains.changeset import (
@@ -87,9 +89,11 @@ class SoftDeprecated(PyVersionChange):
     with "Soft deprecated" linking to the glossary definition.
     """
 
+    _TERM_RE = re.compile(r":term:`([^`]+)`")
+
     def run(self) -> list[Node]:
         versionlabels[self.name] = sphinx_gettext(
-            "Soft deprecated since version %s"
+            ":term:`Soft deprecated` since version %s"
         )
         versionlabel_classes[self.name] = "soft-deprecated"
         try:
@@ -108,38 +112,35 @@ class SoftDeprecated(PyVersionChange):
 
         return result
 
-    @staticmethod
-    def _add_glossary_link(inline: nodes.inline) -> None:
-        """Replace 'Soft deprecated' text with a cross-reference to the
-        :term:`soft deprecated` glossary entry."""
-        marker = sphinx_gettext("Soft deprecated")
-        ref = addnodes.pending_xref(
-            "",
-            nodes.Text(marker),
-            refdomain="std",
-            reftype="term",
-            reftarget="soft deprecated",
-            refwarn=True,
-        )
-
+    @classmethod
+    def _add_glossary_link(cls, inline: nodes.inline) -> None:
+        """Replace :term:`soft deprecated` text with a cross-reference to the
+        'Soft deprecated' glossary entry."""
         for child in inline.children:
             if not isinstance(child, nodes.Text):
                 continue
 
             text = str(child)
-            idx = text.find(marker)
-            if idx < 0:
+            match = cls._TERM_RE.search(text)
+            if match is None:
                 continue
 
-            # Replace the text node with the split parts using docutils API
-            new_nodes: list[nodes.Node] = []
-            if idx > 0:
-                new_nodes.append(nodes.Text(text[:idx]))
+            ref = addnodes.pending_xref(
+                "",
+                nodes.Text(match.group(1)),
+                refdomain="std",
+                reftype="term",
+                reftarget="soft deprecated",
+                refwarn=True,
+            )
 
+            start, end = match.span()
+            new_nodes: list[nodes.Node] = []
+            if start > 0:
+                new_nodes.append(nodes.Text(text[:start]))
             new_nodes.append(ref)
-            remainder = text[idx + len(marker) :]
-            if remainder:
-                new_nodes.append(nodes.Text(remainder))
+            if end < len(text):
+                new_nodes.append(nodes.Text(text[end:]))
 
             child.parent.replace(child, new_nodes)
             break

--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -29,8 +29,7 @@ In extensions/changes.py:
 
 {% trans %}Deprecated since version %s, will be removed in version %s{% endtrans %}
 {% trans %}Deprecated since version %s, removed in version %s{% endtrans %}
-{% trans %}Soft deprecated since version %s{% endtrans %}
-{% trans %}Soft deprecated{% endtrans %}
+{% trans %}:term:`Soft deprecated` since version %s{% endtrans %}
 
 In docsbuild-scripts, when rewriting indexsidebar.html with actual versions:
 


### PR DESCRIPTION
`:term:` will be much clearer for translators, avoids any issues with the substitution and also means less work for translators. For example, with:

```po
msgid ":term:`Soft deprecated` since version %s"
msgstr ":term:`Sóft déprecated` since Python %s"
```

We get:

<img width="1153" height="242" alt="image" src="https://github.com/user-attachments/assets/1cd9e667-7261-49c6-9b31-489f2ffb2c59" />

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
